### PR TITLE
Simplify build [WIP]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,24 @@
+version: '{build}'
+image: Ubuntu
+stack: docker
+configuration: Release
+init: |
+  if [ -e "/usr/local/bin/docker-compose" ]; then
+    exit 0
+  fi
+  curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  chmod +x docker-compose
+  sudo mv docker-compose /usr/local/bin
+cache:
+  - /usr/local/bin -> .appveyor.yml
+build:
+  verbosity: minimal
+test_script:
+- sh: |
+    dotnet test test/Kongverge.Tests/Kongverge.Tests.csproj
+    docker-compose -f test/Kongverge.IntegrationTests/docker-compose.yml up --no-start
+    dotnet test test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
+    docker-compose -f test/Kongverge.IntegrationTests/docker-compose.yml down
+artifacts:
+- path: '**\*.nupkg'
+deploy: off

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ artifacts/
 .nyc_output/
 coverage/
 .dotnetcli/
+.idea
 
 launchSettings.json
 

--- a/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
+++ b/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
@@ -26,7 +26,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
-  <Target Name="BuildDockerServices" AfterTargets="Build">
+  <Target Name="BuildDockerServices" BeforeTargets="VSTest">
     <Message Importance="high" Text="Building Docker services..." />
     <Exec Command="docker-compose up --no-start" />
   </Target>

--- a/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
+++ b/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
@@ -28,7 +28,7 @@
 
   <Target Name="BuildDockerServices" BeforeTargets="VSTest">
     <Message Importance="high" Text="Building Docker services..." />
-    <Exec Command="docker-compose up --no-start" />
+    <Exec Command="docker-compose -f &quot;$(ProjectDir)docker-compose.yml&quot; up --no-start" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Defer docker for when you run `dotnet test`, so that `dotnet build` is simple and has less dependencies.