### PR TITLE
Flush StreamWriter asynchronously

### DIFF
--- a/src/Kongverge/Services/ConfigFileWriter.cs
+++ b/src/Kongverge/Services/ConfigFileWriter.cs
@@ -33,6 +33,7 @@ namespace Kongverge.Services
             using (var writer = new StreamWriter(stream))
             {
                 await writer.WriteAsync(json);
+                await writer.FlushAsync();
             }
         }
 


### PR DESCRIPTION
Implementing best practice from here:

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-call-flushasync-on-streamwriters-or-streams-before-calling-dispose