### PR TITLE
Configuration validation

### DIFF
--- a/src/Kongverge/DTOs/GlobalConfig.cs
+++ b/src/Kongverge/DTOs/GlobalConfig.cs
@@ -13,6 +13,16 @@ namespace Kongverge.DTOs
 
         public async Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
+            await ValidatePlugins(availablePlugins, errorMessages);
+        }
+
+        private async Task ValidatePlugins(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
+        {
+            if (Plugins == null)
+            {
+                errorMessages.Add("Plugins cannot be null.");
+                return;
+            }
             foreach (var plugin in Plugins)
             {
                 await plugin.Validate(availablePlugins, errorMessages);

--- a/src/Kongverge/DTOs/GlobalConfig.cs
+++ b/src/Kongverge/DTOs/GlobalConfig.cs
@@ -11,11 +11,11 @@ namespace Kongverge.DTOs
         [JsonProperty("plugins")]
         public IReadOnlyList<KongPlugin> Plugins { get; set; } = Array.Empty<KongPlugin>();
 
-        public async Task Validate(ICollection<string> errorMessages)
+        public async Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
             foreach (var plugin in Plugins)
             {
-                await plugin.Validate(errorMessages);
+                await plugin.Validate(availablePlugins, errorMessages);
             }
         }
 

--- a/src/Kongverge/DTOs/IValidatableObject.cs
+++ b/src/Kongverge/DTOs/IValidatableObject.cs
@@ -5,6 +5,6 @@ namespace Kongverge.DTOs
 {
     public interface IValidatableObject
     {
-        Task Validate(ICollection<string> errorMessages);
+        Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages);
     }
 }

--- a/src/Kongverge/DTOs/KongPlugin.cs
+++ b/src/Kongverge/DTOs/KongPlugin.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Kongverge.Helpers;
@@ -6,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Kongverge.DTOs
 {
-    public sealed class KongPlugin : KongObject, IKongEquatable<KongPlugin>, IValidatableObject
+    public class KongPlugin : KongObject, IKongEquatable<KongPlugin>, IValidatableObject
     {
         public const string ObjectName = "plugin";
 
@@ -48,9 +49,12 @@ namespace Kongverge.DTOs
             RouteId = null;
         }
 
-        public Task Validate(ICollection<string> errorMessages)
+        public virtual Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
-            // TODO: Add validation
+            if (!availablePlugins.Contains(Name))
+            {
+                errorMessages.Add($"Plugin '{Name}' is not available on Kong server.");
+            }
             return Task.CompletedTask;
         }
 

--- a/src/Kongverge/DTOs/KongRoute.cs
+++ b/src/Kongverge/DTOs/KongRoute.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Kongverge.DTOs
 {
-    public sealed class KongRoute : KongObject, IKongPluginHost, IKongEquatable<KongRoute>, IValidatableObject
+    public class KongRoute : KongObject, IKongPluginHost, IKongEquatable<KongRoute>, IValidatableObject
     {
         public const string ObjectName = "route";
 
@@ -75,7 +75,7 @@ namespace Kongverge.DTOs
             plugin.RouteId = Id;
         }
 
-        public Task Validate(ICollection<string> errorMessages)
+        public virtual async Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
             if (IsNullOrEmpty(Protocols) || Protocols.Any(string.IsNullOrWhiteSpace))
             {
@@ -85,7 +85,7 @@ namespace Kongverge.DTOs
             if (IsNullOrEmpty(Hosts) && IsNullOrEmpty(Methods) && IsNullOrEmpty(Paths))
             {
                 errorMessages.Add("At least one of 'hosts', 'methods', or 'paths' must be set");
-                return Task.CompletedTask;
+                return;
             }
 
             if (Hosts?.Any(string.IsNullOrWhiteSpace) == true)
@@ -103,7 +103,10 @@ namespace Kongverge.DTOs
                 errorMessages.Add("Route Paths cannot contain null or empty values");
             }
 
-            return Task.CompletedTask;
+            foreach (var plugin in Plugins)
+            {
+                await plugin.Validate(availablePlugins, errorMessages);
+            }
         }
 
         private static bool IsNullOrEmpty(IEnumerable<string> values)

--- a/src/Kongverge/DTOs/KongService.cs
+++ b/src/Kongverge/DTOs/KongService.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Kongverge.DTOs
 {
-    public sealed class KongService : KongObject, IKongPluginHost, IKongEquatable<KongService>, IKongvergeConfigObject
+    public class KongService : KongObject, IKongPluginHost, IKongEquatable<KongService>, IKongvergeConfigObject
     {
         public const string ObjectName = "service";
 
@@ -86,24 +86,26 @@ namespace Kongverge.DTOs
             plugin.ServiceId = Id;
         }
 
-        public async Task Validate(ICollection<string> errorMessages)
+        public async Task Validate(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
-            await ValidateRoutesAreValid(errorMessages);
+            foreach (var plugin in Plugins)
+            {
+                await plugin.Validate(availablePlugins, errorMessages);
+            }
+            await ValidateRoutes(availablePlugins, errorMessages);
         }
 
-        private async Task ValidateRoutesAreValid(ICollection<string> errorMessages)
+        private async Task ValidateRoutes(IReadOnlyCollection<string> availablePlugins, ICollection<string> errorMessages)
         {
             if (Routes == null || !Routes.Any())
             {
-                errorMessages.Add("Routes cannot be null or empty");
+                errorMessages.Add("Routes cannot be null or empty.");
                 return;
             }
             foreach (var route in Routes)
             {
-                await route.Validate(errorMessages);
+                await route.Validate(availablePlugins, errorMessages);
             }
-
-            // TODO: Check if routes Clash
         }
 
         public string ToConfigJson()

--- a/src/Kongverge/Workflow/KongvergeWorkflow.cs
+++ b/src/Kongverge/Workflow/KongvergeWorkflow.cs
@@ -35,10 +35,11 @@ namespace Kongverge.Workflow
 
         public override async Task<int> DoExecute()
         {
+            var availablePlugins = KongConfiguration.Plugins.Available.Where(x => x.Value).Select(x => x.Key).ToArray();
             KongvergeConfiguration targetConfiguration;
             try
             {
-                targetConfiguration = await _configReader.ReadConfiguration(Configuration.InputFolder);
+                targetConfiguration = await _configReader.ReadConfiguration(Configuration.InputFolder, availablePlugins);
             }
             catch (DirectoryNotFoundException ex)
             {

--- a/test/Kongverge.IntegrationTests/FolderInvalidData/global.json
+++ b/test/Kongverge.IntegrationTests/FolderInvalidData/global.json
@@ -7,6 +7,10 @@
         "generator": "uuid#counter",
         "header_name": "x-correlation-id"
       }
+    },
+    {
+      "name": "unavailable",
+      "config": { }
     }
   ]
 }

--- a/test/Kongverge.IntegrationTests/FolderInvalidData/service2.json
+++ b/test/Kongverge.IntegrationTests/FolderInvalidData/service2.json
@@ -1,12 +1,13 @@
 {
-  "host": "www.service2.com",
+  "host": ":",
   "name": "service2",
   "port": 80,
-  "protocol": "http",
-  "retries": 5,
-  "connect_timeout": 60000,
-  "read_timeout": 60000,
-  "write_timeout": 60000,
+  "path": "path:invalid", 
+  "protocol": "junk",
+  "retries": 26,
+  "connect_timeout": 300001,
+  "read_timeout": 300001,
+  "write_timeout": 300001,
   "plugins": [
     {
       "name": "request-termination",

--- a/test/Kongverge.IntegrationTests/FolderInvalidData/service3.json
+++ b/test/Kongverge.IntegrationTests/FolderInvalidData/service3.json
@@ -28,6 +28,12 @@
           "config": { }
         }
       ]
+    },
+    {
+      "hosts": null,
+      "paths": null,
+      "protocols": null,
+      "methods": null
     }
   ]
 }

--- a/test/Kongverge.Tests/DTOs/GlobalConfigTests.cs
+++ b/test/Kongverge.Tests/DTOs/GlobalConfigTests.cs
@@ -1,10 +1,16 @@
+using AutoFixture;
 using Kongverge.DTOs;
 using TestStack.BDDfy;
 
 namespace Kongverge.Tests.DTOs
 {
     [Story(Title = nameof(GlobalConfig) + nameof(IValidatableObject.Validate))]
-    public class GlobalConfigValidationScenarios : KongPluginHostValidationScenarios<GlobalConfig> { }
+    public class GlobalConfigValidationScenarios : KongPluginHostValidationScenarios<GlobalConfig>
+    {
+        protected override void AValidInstanceWithExamplePlugins() => Instance = Build<GlobalConfig>()
+            .With(x => x.Plugins, GetExampleCollection<KongPlugin>(Plugins))
+            .Create();
+    }
 
     [Story(Title = nameof(GlobalConfig) + nameof(IKongvergeConfigObject.ToConfigJson))]
     public class GlobalConfigSerializationScenarios : KongvergeConfigObjectSerializationScenarios<GlobalConfig> { }

--- a/test/Kongverge.Tests/DTOs/GlobalConfigTests.cs
+++ b/test/Kongverge.Tests/DTOs/GlobalConfigTests.cs
@@ -3,6 +3,9 @@ using TestStack.BDDfy;
 
 namespace Kongverge.Tests.DTOs
 {
+    [Story(Title = nameof(GlobalConfig) + nameof(IValidatableObject.Validate))]
+    public class GlobalConfigValidationScenarios : KongPluginHostValidationScenarios<GlobalConfig> { }
+
     [Story(Title = nameof(GlobalConfig) + nameof(IKongvergeConfigObject.ToConfigJson))]
     public class GlobalConfigSerializationScenarios : KongvergeConfigObjectSerializationScenarios<GlobalConfig> { }
 }

--- a/test/Kongverge.Tests/DTOs/KongPluginHostValidationScenarios.cs
+++ b/test/Kongverge.Tests/DTOs/KongPluginHostValidationScenarios.cs
@@ -1,0 +1,37 @@
+using AutoFixture;
+using Kongverge.DTOs;
+using Moq;
+using TestStack.BDDfy;
+using TestStack.BDDfy.Xunit;
+
+namespace Kongverge.Tests.DTOs
+{
+    public abstract class KongPluginHostValidationScenarios<T> : ValidatableObjectSteps<T>
+        where T : IKongPluginHost, IValidatableObject
+    {
+        protected Mock<KongPlugin> PluginMock = new Mock<KongPlugin>();
+
+        protected bool PluginsValid;
+
+        [BddfyFact(DisplayName = nameof(ARandomInstanceWithMockedPlugins))]
+        public void Scenario1() =>
+            this.Given(x => x.ARandomInstanceWithMockedPlugins())
+                .When(x => x.Validating())
+                .Then(x => x.TheErrorMessagesCountIsCorrect())
+                .WithExamples(new ExampleTable(nameof(PluginsValid), nameof(ErrorMessagesCount))
+                {
+                    { true, 0 },
+                    { false, 1 }
+                })
+                .BDDfy();
+
+        protected void ARandomInstanceWithMockedPlugins()
+        {
+            SetupMock(PluginMock, PluginsValid);
+
+            Instance = Build<T>()
+                .With(x => x.Plugins, new[] { PluginMock.Object })
+                .Create();
+        }
+    }
+}

--- a/test/Kongverge.Tests/DTOs/KongPluginHostValidationScenarios.cs
+++ b/test/Kongverge.Tests/DTOs/KongPluginHostValidationScenarios.cs
@@ -1,6 +1,4 @@
-using AutoFixture;
 using Kongverge.DTOs;
-using Moq;
 using TestStack.BDDfy;
 using TestStack.BDDfy.Xunit;
 
@@ -9,29 +7,30 @@ namespace Kongverge.Tests.DTOs
     public abstract class KongPluginHostValidationScenarios<T> : ValidatableObjectSteps<T>
         where T : IKongPluginHost, IValidatableObject
     {
-        protected Mock<KongPlugin> PluginMock = new Mock<KongPlugin>();
+        protected CollectionExample Plugins;
 
-        protected bool PluginsValid;
-
-        [BddfyFact(DisplayName = nameof(ARandomInstanceWithMockedPlugins))]
+        [BddfyFact(DisplayName = nameof(AValidInstanceWithExamplePlugins))]
         public void Scenario1() =>
-            this.Given(x => x.ARandomInstanceWithMockedPlugins())
+            this.Given(x => x.AValidInstanceWithExamplePlugins())
                 .When(x => x.Validating())
                 .Then(x => x.TheErrorMessagesCountIsCorrect())
-                .WithExamples(new ExampleTable(nameof(PluginsValid), nameof(ErrorMessagesCount))
+                .WithExamples(new ExampleTable(nameof(Plugins), nameof(ErrorMessagesCount))
                 {
-                    { true, 0 },
-                    { false, 1 }
+                    { CollectionExample.Null, 1 },
+                    { CollectionExample.Empty, 0 },
+                    { CollectionExample.Valid, 0 },
+                    { CollectionExample.Invalid, 1 }
                 })
                 .BDDfy();
 
-        protected void ARandomInstanceWithMockedPlugins()
-        {
-            SetupMock(PluginMock, PluginsValid);
+        protected abstract void AValidInstanceWithExamplePlugins();
+    }
 
-            Instance = Build<T>()
-                .With(x => x.Plugins, new[] { PluginMock.Object })
-                .Create();
-        }
+    public enum CollectionExample
+    {
+        Null,
+        Empty,
+        Valid,
+        Invalid
     }
 }

--- a/test/Kongverge.Tests/DTOs/KongPluginTests.cs
+++ b/test/Kongverge.Tests/DTOs/KongPluginTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
@@ -33,6 +34,31 @@ namespace Kongverge.Tests.DTOs
             OtherInstance.ConsumerId = this.Create<string>();
             OtherInstance.ServiceId = this.Create<string>();
             OtherInstance.RouteId = this.Create<string>();
+        }
+    }
+
+    [Story(Title = nameof(KongPlugin) + nameof(IValidatableObject.Validate))]
+    public class KongPluginValidationScenarios : ValidatableObjectSteps<KongPlugin>
+    {
+        protected string PluginName;
+
+        [BddfyFact(DisplayName = nameof(ARandomInstanceWithName))]
+        public void Scenario1() =>
+            this.Given(x => x.ARandomInstanceWithName(PluginName))
+                .When(x => x.Validating())
+                .Then(x => x.TheErrorMessagesCountIsCorrect())
+                .WithExamples(new ExampleTable(nameof(PluginName), nameof(ErrorMessagesCount))
+                {
+                    { AvailablePlugins[0], 0 },
+                    { Guid.NewGuid().ToString(), 1 }
+                })
+                .BDDfy();
+
+        protected void ARandomInstanceWithName(string pluginName)
+        {
+            Instance = Build<KongPlugin>()
+                .With(x => x.Name, pluginName)
+                .Create();
         }
     }
 

--- a/test/Kongverge.Tests/DTOs/KongRouteTests.cs
+++ b/test/Kongverge.Tests/DTOs/KongRouteTests.cs
@@ -61,7 +61,111 @@ namespace Kongverge.Tests.DTOs
     }
 
     [Story(Title = nameof(KongRoute) + nameof(IValidatableObject.Validate))]
-    public class KongRouteValidationScenarios : KongPluginHostValidationScenarios<KongRoute> { }
+    public class KongRouteValidationScenarios : KongPluginHostValidationScenarios<KongRoute>
+    {
+        protected ProtocolsExample Protocols;
+        protected StringsExample Hosts;
+        protected StringsExample Methods;
+        protected StringsExample Paths;
+
+        [BddfyFact(DisplayName = nameof(AnInstanceWithExamplePropertyValues))]
+        public void Scenario2() =>
+            this.Given(x => x.AnInstanceWithExamplePropertyValues())
+                .When(x => x.Validating())
+                .Then(x => x.TheErrorMessagesCountIsCorrect())
+                .WithExamples(new ExampleTable(nameof(Protocols), nameof(Hosts), nameof(Methods), nameof(Paths), nameof(ErrorMessagesCount))
+                {
+                    { ProtocolsExample.Null, StringsExample.Null, StringsExample.Null, StringsExample.Null, 5 },
+                    { ProtocolsExample.Empty, StringsExample.Empty, StringsExample.Empty, StringsExample.Empty, 2 },
+                    { ProtocolsExample.Invalid, StringsExample.Valid, StringsExample.Valid, StringsExample.Valid, 1 },
+                    { ProtocolsExample.Http, StringsExample.Valid, StringsExample.Valid, StringsExample.Valid, 0 },
+                    { ProtocolsExample.Https, StringsExample.Valid, StringsExample.Valid, StringsExample.Valid, 0 },
+                    { ProtocolsExample.Both, StringsExample.Valid, StringsExample.Empty, StringsExample.Empty, 0 },
+                    { ProtocolsExample.Both, StringsExample.Empty, StringsExample.Valid, StringsExample.Empty, 0 },
+                    { ProtocolsExample.Both, StringsExample.Empty, StringsExample.Empty, StringsExample.Valid, 0 },
+                    { ProtocolsExample.Invalid, StringsExample.Invalid, StringsExample.Valid, StringsExample.Valid, 2 },
+                    { ProtocolsExample.Invalid, StringsExample.Valid, StringsExample.Invalid, StringsExample.Valid, 2 },
+                    { ProtocolsExample.Invalid, StringsExample.Valid, StringsExample.Valid, StringsExample.Invalid, 2 },
+                    { ProtocolsExample.Invalid, StringsExample.Invalid, StringsExample.Empty, StringsExample.Invalid, 3 },
+                    { ProtocolsExample.Invalid, StringsExample.Invalid, StringsExample.Invalid, StringsExample.Invalid, 4 }
+                })
+                .BDDfy();
+
+        protected override void AValidInstanceWithExamplePlugins() => Instance = Build<KongRoute>()
+            .With(x => x.Plugins, GetExampleCollection<KongPlugin>(Plugins))
+            .With(x => x.Protocols, GetProtocolsExample(ProtocolsExample.Both))
+            .With(x => x.Hosts, GetStringsExample(StringsExample.Empty))
+            .With(x => x.Methods, GetStringsExample(StringsExample.Empty))
+            .With(x => x.Paths, GetStringsExample(StringsExample.Valid))
+            .Create();
+
+        protected void AnInstanceWithExamplePropertyValues()
+        {
+            Instance = Build<KongRoute>()
+                .With(x => x.Plugins, GetExampleCollection<KongPlugin>(CollectionExample.Empty))
+                .With(x => x.Protocols, GetProtocolsExample(Protocols))
+                .With(x => x.Hosts, GetStringsExample(Hosts))
+                .With(x => x.Methods, GetStringsExample(Methods))
+                .With(x => x.Paths, GetStringsExample(Paths))
+                .Create();
+        }
+
+        protected string[] GetProtocolsExample(ProtocolsExample example)
+        {
+            switch (example)
+            {
+                case ProtocolsExample.Null:
+                    return null;
+                case ProtocolsExample.Empty:
+                    return Array.Empty<string>();
+                case ProtocolsExample.Http:
+                    return new[] { "http" };
+                case ProtocolsExample.Https:
+                    return new[] { "https" };
+                case ProtocolsExample.Both:
+                    return new[] { "http", "https" };
+                case ProtocolsExample.Invalid:
+                    return new[] { "junk" };
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(example), example, null);
+            }
+        }
+
+        protected string[] GetStringsExample(StringsExample example)
+        {
+            switch (example)
+            {
+                case StringsExample.Null:
+                    return null;
+                case StringsExample.Empty:
+                    return Array.Empty<string>();
+                case StringsExample.Valid:
+                    return new[] { "valid1", "valid2", "valid3" };
+                case StringsExample.Invalid:
+                    return new[] { null, string.Empty, " ", ":" };
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(example), example, null);
+            }
+        }
+
+        public enum ProtocolsExample
+        {
+            Null,
+            Empty,
+            Http,
+            Https,
+            Both,
+            Invalid
+        }
+
+        public enum StringsExample
+        {
+            Null,
+            Empty,
+            Valid,
+            Invalid
+        }
+    }
 
     [Story(Title = nameof(KongRoute) + nameof(KongObject.ToJsonStringContent))]
     public class KongRouteSerializationScenarios : KongObjectSerializationScenarios<KongRoute>

--- a/test/Kongverge.Tests/DTOs/KongRouteTests.cs
+++ b/test/Kongverge.Tests/DTOs/KongRouteTests.cs
@@ -60,6 +60,9 @@ namespace Kongverge.Tests.DTOs
         }
     }
 
+    [Story(Title = nameof(KongRoute) + nameof(IValidatableObject.Validate))]
+    public class KongRouteValidationScenarios : KongPluginHostValidationScenarios<KongRoute> { }
+
     [Story(Title = nameof(KongRoute) + nameof(KongObject.ToJsonStringContent))]
     public class KongRouteSerializationScenarios : KongObjectSerializationScenarios<KongRoute>
     {

--- a/test/Kongverge.Tests/DTOs/ValidatableObjectSteps.cs
+++ b/test/Kongverge.Tests/DTOs/ValidatableObjectSteps.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -15,8 +16,9 @@ namespace Kongverge.Tests.DTOs
         protected int ErrorMessagesCount;
         protected IReadOnlyList<string> AvailablePlugins = new [] { "plugin1", "plugin2", "plugin3" };
 
-        protected void SetupMock<TMock>(Mock<TMock> mock, bool isValid) where TMock : class, IValidatableObject
+        private Mock<TMock> SetupMock<TMock>(bool isValid) where TMock : class, IValidatableObject
         {
+            var mock = new Mock<TMock>();
             mock
                 .Setup(x => x.Validate(AvailablePlugins, It.IsAny<ICollection<string>>()))
                 .Callback<IReadOnlyCollection<string>, ICollection<string>>((ep, em) =>
@@ -27,6 +29,23 @@ namespace Kongverge.Tests.DTOs
                     }
                 })
                 .Returns(Task.CompletedTask);
+            return mock;
+        }
+
+        protected IReadOnlyList<TItem> GetExampleCollection<TItem>(CollectionExample example) where TItem : class, IValidatableObject
+        {
+            IReadOnlyList<TItem> items = null;
+            if (example == CollectionExample.Empty)
+            {
+                items = Array.Empty<TItem>();
+            }
+            else if (example != CollectionExample.Null)
+            {
+                var mock = SetupMock<TItem>(example == CollectionExample.Valid);
+                items = new[] { mock.Object };
+            }
+
+            return items;
         }
 
         protected Task Validating()

--- a/test/Kongverge.Tests/DTOs/ValidatableObjectSteps.cs
+++ b/test/Kongverge.Tests/DTOs/ValidatableObjectSteps.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using Kongverge.DTOs;
+using Moq;
+
+namespace Kongverge.Tests.DTOs
+{
+    public abstract class ValidatableObjectSteps<T> : Fixture where T : IValidatableObject
+    {
+        private ICollection<string> _errorMessages;
+
+        protected T Instance;
+        protected int ErrorMessagesCount;
+        protected IReadOnlyList<string> AvailablePlugins = new [] { "plugin1", "plugin2", "plugin3" };
+
+        protected void SetupMock<TMock>(Mock<TMock> mock, bool isValid) where TMock : class, IValidatableObject
+        {
+            mock
+                .Setup(x => x.Validate(AvailablePlugins, It.IsAny<ICollection<string>>()))
+                .Callback<IReadOnlyCollection<string>, ICollection<string>>((ep, em) =>
+                {
+                    if (!isValid)
+                    {
+                        em.Add(this.Create<string>());
+                    }
+                })
+                .Returns(Task.CompletedTask);
+        }
+
+        protected Task Validating()
+        {
+            _errorMessages = new List<string>();
+            return Instance.Validate(AvailablePlugins, _errorMessages);
+        }
+
+        protected void TheErrorMessagesCountIsCorrect() => _errorMessages.Count.Should().Be(ErrorMessagesCount);
+    }
+}

--- a/test/Kongverge.Tests/Workflow/KongvergeWorkflowScenarios.cs
+++ b/test/Kongverge.Tests/Workflow/KongvergeWorkflowScenarios.cs
@@ -174,10 +174,10 @@ namespace Kongverge.Tests.Workflow
         }
 
         protected void NonExistentInputFolder() =>
-            GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder)).ThrowsAsync(new DirectoryNotFoundException());
+            GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder, It.IsAny<IReadOnlyCollection<string>>())).ThrowsAsync(new DirectoryNotFoundException());
 
         protected void InvalidTargetConfiguration() =>
-            GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder)).ThrowsAsync(new InvalidConfigurationFilesException(string.Empty));
+            GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder, It.IsAny<IReadOnlyCollection<string>>())).ThrowsAsync(new InvalidConfigurationFilesException(string.Empty));
 
         protected void AnAssortmentOfExistingServicesAndGlobalConfig()
         {
@@ -306,7 +306,7 @@ namespace Kongverge.Tests.Workflow
             SetupTargetConfiguration();
         }
 
-        protected void SetupTargetConfiguration() => GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder)).ReturnsAsync(Target);
+        protected void SetupTargetConfiguration() => GetMock<ConfigFileReader>().Setup(x => x.ReadConfiguration(Settings.InputFolder, It.IsAny<IReadOnlyCollection<string>>())).ReturnsAsync(Target);
 
         protected void NoServicesAreAdded() =>
             GetMock<IKongAdminWriter>().Verify(x => x.AddService(It.IsAny<KongService>()), Times.Never);


### PR DESCRIPTION
Resolves #6

The only thing mentioned in that issue which it doesn't do is that it can't validate plugin schema, due to the schema returned from Kong not being a valid [JSON Schema](https://json-schema.org/specification.html) object.