### PR TITLE
Remove fault tolerance, improve logging, update NuGet packages, update target framwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Desired State Configuration tool for [Kong](https://github.com/kong/kong).
 
-A command-line tool written in cross-platform [.NET Core 2.1](http://dot.net).
+A command-line tool written in cross-platform [.NET Core 2.2](http://dot.net).
 
 See the [tutorial](Tutorial.md) for examples of how to use Kongverge.
 

--- a/src/Kongverge/Commands.cs
+++ b/src/Kongverge/Commands.cs
@@ -60,6 +60,7 @@ namespace Kongverge
             var connectionDetails = app.GetRequiredService<KongAdminApiConnectionDetails>();
             connectionDetails.Host = Host;
             connectionDetails.Port = Port;
+            Log.Information($"Targeting kong host: {connectionDetails.Host}");
 
             if (!string.IsNullOrWhiteSpace(BasicAuthUser))
             {

--- a/src/Kongverge/Commands.cs
+++ b/src/Kongverge/Commands.cs
@@ -34,9 +34,6 @@ namespace Kongverge
         [Option("-p|--password=<Password>", "Optional. Basic Auth protected Kong Admin API Password (can be passed via redirected stdin)", CommandOptionType.SingleOrNoValue)]
         public Password BasicAuthPassword { get; }
 
-        [Option("-ft|--faultTolerance <FaultTolerance>", "Optional. True or false (defaults to false). If true, allows Kongverge to complete a run through regardless of exceptions", CommandOptionType.SingleValue)]
-        public bool FaultTolerance { get; } = false;
-
         protected ValidationResult OnValidate(ValidationContext validationContext, CommandLineContext commandLineContext)
         {
             if (!string.IsNullOrWhiteSpace(BasicAuthUser) && string.IsNullOrWhiteSpace(BasicAuthPassword.Value))
@@ -69,8 +66,6 @@ namespace Kongverge
                 var byteArray = Encoding.ASCII.GetBytes($"{BasicAuthUser}:{BasicAuthPassword.Value}");
                 connectionDetails.AuthenticationHeader = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
             }
-
-            app.GetRequiredService<KongvergeWorkflowArguments>().FaultTolerance = FaultTolerance;
         }
 
         public Task<int> OnExecuteAsync(CommandLineApplication app)

--- a/src/Kongverge/DTOs/KongvergeWorkflowArguments.cs
+++ b/src/Kongverge/DTOs/KongvergeWorkflowArguments.cs
@@ -4,6 +4,5 @@ namespace Kongverge.DTOs
     {
         public string InputFolder { get; set; }
         public bool DryRun { get; set; } = false;
-        public bool FaultTolerance { get; set; } = false;
     }
 }

--- a/src/Kongverge/Kongverge.csproj
+++ b/src/Kongverge/Kongverge.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Description>A desired state configuration tool for Kong</Description>
     <PackageTags>kong api gateway desired state configuration json</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Kongverge/Kongverge.csproj
+++ b/src/Kongverge/Kongverge.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -10,14 +10,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JsonDiffPatch.Net" Version="2.1.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="MinVer" Version="1.0.0">
+    <PackageReference Include="MinVer" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.2" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Kongverge/Program.cs
+++ b/src/Kongverge/Program.cs
@@ -64,13 +64,12 @@ namespace Kongverge
             {
                 var args = s.GetRequiredService<KongvergeWorkflowArguments>();
 
+                var connectionDetails = s.GetRequiredService<KongAdminApiConnectionDetails>();
                 if (args.DryRun)
                 {
-                    Log.Information("Performing dry run: No writes to Kong will occur");
+                    Log.Information($"Performing dry run: No changes will be made to {connectionDetails.Host}");
                     return s.GetRequiredService<KongAdminDryRun>();
                 }
-
-                var connectionDetails = s.GetRequiredService<KongAdminApiConnectionDetails>();
 
                 Log.Information($"Performing live integration: Changes will be made to {connectionDetails.Host}");
                 return s.GetRequiredService<KongAdminWriter>();

--- a/src/Kongverge/Services/EnsureSuccessHandler.cs
+++ b/src/Kongverge/Services/EnsureSuccessHandler.cs
@@ -1,4 +1,3 @@
-using Serilog;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,11 +6,7 @@ namespace Kongverge.Services
 {
     public class EnsureSuccessHandler : DelegatingHandler
     {
-        private bool _faultTolerance;
-        public EnsureSuccessHandler(bool faultTolerance = false, HttpMessageHandler innerHandler = null) : base(innerHandler ?? new HttpClientHandler())
-        {
-            _faultTolerance = faultTolerance;
-        }
+        public EnsureSuccessHandler(HttpMessageHandler innerHandler = null) : base(innerHandler ?? new HttpClientHandler()) { }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -22,11 +17,6 @@ namespace Kongverge.Services
             }
 
             var responseBody = await response.Content.ReadAsStringAsync();
-            if (_faultTolerance)
-            {
-                Log.Error("Error converging target configuration: StatusCode: {StatusCode}, ResponseBody: {ResponseBody}", response.StatusCode, responseBody);
-                return new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent("{}") };
-            }
             throw new KongException(response.StatusCode, responseBody);
         }
     }

--- a/src/Kongverge/Services/KongAdminHttpClient.cs
+++ b/src/Kongverge/Services/KongAdminHttpClient.cs
@@ -6,7 +6,7 @@ namespace Kongverge.Services
 {
     public class KongAdminHttpClient : HttpClient
     {
-        public KongAdminHttpClient(KongAdminApiConnectionDetails connectionDetails, HttpMessageHandler innerHandler = null, KongvergeWorkflowArguments kongvergeWorkflowArguments = null) : base(new EnsureSuccessHandler(kongvergeWorkflowArguments == null ? false : kongvergeWorkflowArguments.FaultTolerance, innerHandler))
+        public KongAdminHttpClient(KongAdminApiConnectionDetails connectionDetails, HttpMessageHandler innerHandler = null) : base(new EnsureSuccessHandler(innerHandler))
         {
             BaseAddress = new Uri($"http://{connectionDetails.Host}:{connectionDetails.Port}");
             DefaultRequestHeaders.Authorization = connectionDetails.AuthenticationHeader;

--- a/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
+++ b/test/Kongverge.IntegrationTests/Kongverge.IntegrationTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Kongverge.Tests/Kongverge.Tests.csproj
+++ b/test/Kongverge.Tests/Kongverge.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Kongverge.Tests/Kongverge.Tests.csproj
+++ b/test/Kongverge.Tests/Kongverge.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
+    <PackageReference Include="AutoFixture" Version="4.9.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Moq.AutoMock" Version="1.2.0.120" />
     <PackageReference Include="TestStack.BDDfy.Xunit" Version="1.0.0" />


### PR DESCRIPTION
Fault tolerance was added without any tests. This was done for specific reasons that were only applicable to Just Eat's use case, which have now been mitigated in another way. Besides the problem of not having any tests, the idea of having a desired state configuration tool silently succeeding despite errors breaks the intention of the tool to begin with. A desired state should be applied in full, or not at all.

I've also taken this opportunity to do a bit of minor improvement to logging output, update NuGet packages, and target the latest version of .NET Core.